### PR TITLE
chore(deps): Consolidated dependency updates

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+      uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
       with:
         egress-policy: audit
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+      uses: github/codeql-action/init@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+      uses: github/codeql-action/autobuild@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+      uses: github/codeql-action/analyze@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Checkout your code repository to scan
     - name: Harden Runner
-      uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+      uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
       with:
         egress-policy: audit
 

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -55,6 +55,6 @@ jobs:
 
       # Upload results to the Security tab
     - name: Upload OSSAR results
-      uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+      uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
       with:
         sarif_file: ${{ steps.ossar.outputs.sarifFile }}

--- a/.github/workflows/powershell-analysis.yml
+++ b/.github/workflows/powershell-analysis.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/powershell-analysis.yml
+++ b/.github/workflows/powershell-analysis.yml
@@ -48,6 +48,6 @@ jobs:
       
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -71,6 +71,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/snyk-analysis.yml
+++ b/.github/workflows/snyk-analysis.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+      uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
       with:
         egress-policy: audit
 

--- a/.github/workflows/snyk-analysis.yml
+++ b/.github/workflows/snyk-analysis.yml
@@ -40,6 +40,6 @@ jobs:
         image: your/image-to-test
         args: --file=Dockerfile
     - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+      uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
       with:
         sarif_file: snyk.sarif

--- a/.github/workflows/snyk-analysis.yml
+++ b/.github/workflows/snyk-analysis.yml
@@ -30,7 +30,7 @@ jobs:
       # Snyk can be used to break the build when it detects vulnerabilities.
       # In this case we want to upload the issues to GitHub Code Scanning
       continue-on-error: true
-      uses: snyk/actions/docker@cdb760004ba9ea4d525f2e043745dfe85bb9077e # master
+      uses: snyk/actions/docker@28606799782bc8e809f4076e9f8293bc4212d05e # master
       env:
         # In order to use the Snyk Action you will need to have a Snyk API token.
         # More details in https://github.com/snyk/actions#getting-your-snyk-token

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: "ubuntu-24.04"
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -27,7 +27,7 @@ jobs:
           docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37 # master
+        uses: aquasecurity/trivy-action@77137e9dc3ab1b329b7c8a38c2eb7475850a14e8 # master
         with:
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
           format: 'template'

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -36,6 +36,6 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           sarif_file: 'trivy-results.sarif'

--- a/Linux/Blackarch/optional/requirements.txt
+++ b/Linux/Blackarch/optional/requirements.txt
@@ -44,7 +44,7 @@ exceptiongroup
 fbmessenger
 filelock
 fire
-fonttools==4.58.2
+fonttools==4.58.5
 frozenlist
 fsspec
 future

--- a/Linux/Blackarch/optional/requirements.txt
+++ b/Linux/Blackarch/optional/requirements.txt
@@ -1,4 +1,4 @@
-typeguard==4.4.3
+typeguard==4.4.4
 APScheduler
 CacheControl
 aio-pika

--- a/Linux/Blackarch/optional/requirements.txt
+++ b/Linux/Blackarch/optional/requirements.txt
@@ -90,7 +90,7 @@ packageurl-python
 pamqp
 partd
 pathy
-Pillow==11.2.1
+Pillow==11.3.0
 pipx
 pluggy
 policy-sentry

--- a/Linux/Blackarch/optional/requirements.txt
+++ b/Linux/Blackarch/optional/requirements.txt
@@ -83,7 +83,7 @@ mpi4py
 msgpack
 multidict
 Naked
-numpy==2.3.0
+numpy==2.3.1
 openai
 opt-einsum
 packageurl-python

--- a/Linux/Python/requirements.txt
+++ b/Linux/Python/requirements.txt
@@ -44,7 +44,7 @@ exceptiongroup
 fbmessenger
 filelock
 fire
-fonttools==4.58.2
+fonttools==4.58.5
 frozenlist
 fsspec
 future

--- a/Linux/Python/requirements.txt
+++ b/Linux/Python/requirements.txt
@@ -1,4 +1,4 @@
-typeguard==4.4.3
+typeguard==4.4.4
 APScheduler
 CacheControl
 aio-pika

--- a/Linux/Python/requirements.txt
+++ b/Linux/Python/requirements.txt
@@ -89,7 +89,7 @@ packageurl-python
 pamqp
 partd
 pathy
-Pillow==11.2.1
+Pillow==11.3.0
 pipx
 pluggy
 policy-sentry

--- a/Linux/Python/requirements.txt
+++ b/Linux/Python/requirements.txt
@@ -82,7 +82,7 @@ ml-dtypes
 msgpack
 multidict
 Naked
-numpy==2.3.0
+numpy==2.3.1
 openai
 opt-einsum
 packageurl-python

--- a/SuperCluster/ArchLinux/Python/requirements.txt
+++ b/SuperCluster/ArchLinux/Python/requirements.txt
@@ -44,7 +44,7 @@ exceptiongroup
 fbmessenger
 filelock
 fire
-fonttools==4.58.2
+fonttools==4.58.5
 frozenlist
 fsspec
 future

--- a/SuperCluster/ArchLinux/Python/requirements.txt
+++ b/SuperCluster/ArchLinux/Python/requirements.txt
@@ -1,4 +1,4 @@
-typeguard==4.4.3
+typeguard==4.4.4
 APScheduler
 CacheControl
 aio-pika

--- a/SuperCluster/ArchLinux/Python/requirements.txt
+++ b/SuperCluster/ArchLinux/Python/requirements.txt
@@ -90,7 +90,7 @@ packageurl-python
 pamqp
 partd
 pathy
-Pillow==11.2.1
+Pillow==11.3.0
 pipx
 pluggy
 policy-sentry

--- a/SuperCluster/ArchLinux/Python/requirements.txt
+++ b/SuperCluster/ArchLinux/Python/requirements.txt
@@ -83,7 +83,7 @@ mpi4py
 msgpack
 multidict
 Naked
-numpy==2.3.0
+numpy==2.3.1
 openai
 opt-einsum
 packageurl-python

--- a/SuperCluster/Kali/Python/requirements.txt
+++ b/SuperCluster/Kali/Python/requirements.txt
@@ -44,7 +44,7 @@ exceptiongroup
 fbmessenger
 filelock
 fire
-fonttools==4.58.2
+fonttools==4.58.5
 frozenlist
 fsspec
 future

--- a/SuperCluster/Kali/Python/requirements.txt
+++ b/SuperCluster/Kali/Python/requirements.txt
@@ -1,4 +1,4 @@
-typeguard==4.4.3
+typeguard==4.4.4
 APScheduler
 CacheControl
 aio-pika

--- a/SuperCluster/Kali/Python/requirements.txt
+++ b/SuperCluster/Kali/Python/requirements.txt
@@ -90,7 +90,7 @@ packageurl-python
 pamqp
 partd
 pathy
-Pillow==11.2.1
+Pillow==11.3.0
 pipx
 pluggy
 policy-sentry

--- a/SuperCluster/Kali/Python/requirements.txt
+++ b/SuperCluster/Kali/Python/requirements.txt
@@ -83,7 +83,7 @@ mpi4py
 msgpack
 multidict
 Naked
-numpy==2.3.0
+numpy==2.3.1
 openai
 opt-einsum
 packageurl-python

--- a/SuperCluster/macOS/Python/requirements.txt
+++ b/SuperCluster/macOS/Python/requirements.txt
@@ -44,7 +44,7 @@ exceptiongroup
 fbmessenger
 filelock
 fire
-fonttools==4.58.2
+fonttools==4.58.5
 frozenlist
 fsspec
 future

--- a/SuperCluster/macOS/Python/requirements.txt
+++ b/SuperCluster/macOS/Python/requirements.txt
@@ -1,4 +1,4 @@
-typeguard==4.4.3
+typeguard==4.4.4
 APScheduler
 CacheControl
 aio-pika

--- a/SuperCluster/macOS/Python/requirements.txt
+++ b/SuperCluster/macOS/Python/requirements.txt
@@ -90,7 +90,7 @@ packageurl-python
 pamqp
 partd
 pathy
-Pillow==11.2.1
+Pillow==11.3.0
 pipx
 pluggy
 policy-sentry

--- a/SuperCluster/macOS/Python/requirements.txt
+++ b/SuperCluster/macOS/Python/requirements.txt
@@ -83,7 +83,7 @@ mpi4py
 msgpack
 multidict
 Naked
-numpy==2.3.0
+numpy==2.3.1
 openai
 opt-einsum
 packageurl-python


### PR DESCRIPTION
This PR consolidates all pending dependency updates from Renovate:

- Update aquasecurity/trivy-action digest to 77137e9
- Update dependency pillow to v11.3.0  
- Update snyk/actions digest to 2860679
- Update dependency numpy to v2.3.1
- Update dependency typeguard to v4.4.4
- Update dependency fonttools to v4.58.5
- Update github/codeql-action action to v3.29.2
- Update step-security/harden-runner action to v2.12.2

All changes have been merged and tested for compatibility.